### PR TITLE
🔐 Reveal user's email only to the same, logged-in user

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
-  helper_method :current_user, :logged_in?
+  helper_method :current_user, :logged_in?, :is_current_user?
 
   def current_user
     return nil unless session[:token]
@@ -10,6 +10,10 @@ class ApplicationController < ActionController::Base
 
   def logged_in?
     !!current_user
+  end
+
+  def is_current_user?(user)
+    logged_in? && current_user.id == user.id
   end
 
   def login!(user)

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,8 +1,9 @@
-json.extract! user,
-  :id,
-  :username,
-  :email,
-  :description,
-  :avatar_hero,
-  :avatar_thumb,
-  :avatar_square
+json.user do
+  json.id             user.id
+  json.username       user.username
+  json.email          is_current_user?(user) ? user.email : nil # protect PII!
+  json.description    user.description
+  json.avatar_hero    user.avatar_hero
+  json.avatar_thumb   user.avatar_thumb
+  json.avatar_square  user.avatar_square
+end


### PR DESCRIPTION
Credits to @NemyaNation's https://github.com/hankfanchiu/chime/pull/2 for finding this vulnerability, which exposes any user's email (a potentially real address) to not only any other user but also to the public.

This change set nullifies the JSON `user` object's `email` property, if the current user is _not_ the requested user.